### PR TITLE
virtuosoでデバッグするための環境の作成

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  sparql:
+    image: tenforce/virtuoso:1.3.1-virtuoso7.2.2
+    volumes:
+      - .:/data/toLoad
+    ports:
+      - "8890:8890"


### PR DESCRIPTION
croMisaP さんとも話していたとおり im@sprql では違うものを使っているので，そこらへんはいろいろと考えながらやってもらえればと思っていて，virtuosoを使わなくてもいいと思いますが，RDFのデバッグ環境で簡単なものとしてvirtuosoが使えるんじゃないかといった提案です．

リポジトリのルートで

```
$ docker-compose up
```

をやるとsparqleを `http://localhost:8890/sparql` でたたけるようになります．

手元で

```
PREFIX wwv: <http://wwkb.kiridaruma.net/resources/vocabulary.ttl#>
select ?s where { ?s a wwv:Witch }
```

というクエリを叩いて以下のようなデータが得られることを確認しました．

![image](https://user-images.githubusercontent.com/10114717/58114274-6965d080-7c32-11e9-9a97-6818b4344a68.png)

RDFを更新した場合は以下の流れで再ロードできます

```
$ docker-compose down
$ docker-compose up
```